### PR TITLE
parse can split tokens

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ function Entry(data, opts){
   this.event = getEvent(data.message);
   this.line = data.line;
   this.message = data.message || '';
+  this.split_tokens = data.line.split(' ');
   this.thread = data.thread;
 
   var match = regret('connectionAccepted', data.message);

--- a/test/split_tokens.js
+++ b/test/split_tokens.js
@@ -1,0 +1,20 @@
+var assert = require('assert'),
+    log    = require('./..');
+
+describe('parse', function() {
+  it('should split tokens', function() {
+    line = '2014-06-02T14:26:48.300-0400 [initandlisten] query admin.system.roles ' +
+      'planSummary: EOF ntoreturn:0 ntoskip:0 nscanned:0 nscannedObjects:0 ' + 
+      'keyUpdates:0 numYields:0 locks(micros) W:2347 r:243 nreturned:0 ' +
+      'reslen:20 0ms'
+    expected = [
+      "2014-06-02T14:26:48.300-0400", "[initandlisten]", "query", 
+      "admin.system.roles", "planSummary:", "EOF", "ntoreturn:0", "ntoskip:0", 
+      "nscanned:0", "nscannedObjects:0", "keyUpdates:0", "numYields:0", 
+      "locks(micros)", "W:2347", "r:243", "nreturned:0", "reslen:20", "0ms"
+    ],
+    res = log.parse(line);
+
+    assert.deepEqual(res[0].split_tokens, expected);
+  });
+});


### PR DESCRIPTION
@imlucas 

Parse now has split_tokens field like mtools does.
Also, will be using tokenizer to parse nested expressions and fields e.g. {{{{}}}}.
