### PR TITLE
locks and made the operation stat parsing generic/not hard coded

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
 var regret    = require('./patterns'),
     Set       = require('set');
 
-// the values of these stats will be non-negative integers so {0, 1, 2, ...}
-var operationStats = new Set([ 'keyUpdates', 'nmoved', 'nreturned', 'nscanned', 
-  'nscannedObjects', 'ntoskip', 'ntoreturn', 'numYields', 'reslen' ]),
-    operationTypes = new Set([ 'command', 'delete', 'getmore', 'query', 
-  'update' ]);
+var operationTypes = new Set([ 
+  'command', 
+  'delete', 
+  'getmore', 
+  'query', 
+  'remove', 
+  'update' 
+]);
 
 function errorMessage(msg){
   if(msg.indexOf('mongod instance already running?') > -1){
@@ -59,7 +62,7 @@ function Entry(data, opts){
 
     this.operation = this.split_tokens[2];
 
-    var colonIndex, key, token;
+    var colonIndex, key, token, intValue;
 
     for (var i = 4; i < this.split_tokens.length; i++) {
       token = this.split_tokens[i];
@@ -68,9 +71,10 @@ function Entry(data, opts){
       // parsing operation stat fields
       if (colonIndex) {
         key = token.substring(0, colonIndex);
+        intValue = parseInt(token.substring(colonIndex + 1));
 
-        if (operationStats.contains(key))
-          this[key] = token.substring(colonIndex + 1); 
+        if (intValue != NaN)
+          this[key] = intValue; 
       }
     }
   }

--- a/logparse-spec.md
+++ b/logparse-spec.md
@@ -160,29 +160,32 @@ some data specific to the event. They are returned as a document of the form
 
 ## Full list of names to extract
 
-- `timestamp`
-- `timestamp_format`
-- `thread`
-- `conn`
-- `operation`
-- `namespace`
-- `database`
-- `collection`
-- `duration`
-- `query`
-- `query_shape`
-- `sort_shape`
-- `nscanned`
-- `ntoreturn`
-- `ntoskip`
-- `nupdated`
-- `nreturned`
-- `ninserted`
-- `ndeleted`
-- `nmoved`
-- `numYields`
-- `r`
-- `w`
-- `event`
+- [x] `R`
+- [x] `W`
+- [ ] `timestamp`
+- [ ] `timestamp_format`
+- [x] `thread`
+- [x] `conn`
+- [x] `operation`
+- [x] `namespace`
+- [x] `database`
+- [x] `collection`
+- [x] `duration`
+- [ ] `query`
+- [ ] `query_shape`
+- [ ] `sort_shape`
+- [x] `index`
+- [x] `nscanned`
+- [x] `ntoreturn`
+- [x] `ntoskip`
+- [x] `nupdated`
+- [x] `nreturned`
+- [x] `ninserted`
+- [x] `ndeleted`
+- [x] `nmoved`
+- [x] `numYields`
+- [x] `r`
+- [x] `w`
+- [ ] `event`
 
 

--- a/test/operation.js
+++ b/test/operation.js
@@ -5,22 +5,25 @@ describe('parse', function() {
   // query operation
   it('should match parse the query operation fields', function() {
     var lines = [
-      '2014-06-02T14:26:48.300-0400 [initandlisten] query admin.system ' +
+      '2014-06-02T14:26:48.300-0400 [initandlisten] command admin.system ' +
         'planSummary: EOF ntoreturn:0 ntoskip:0 nscanned:0 nscannedObjects:0 ' + 
         'keyUpdates:0 numYields:0 locks(micros) W:2347 r:243 nreturned:30000 ' +
-        'reslen:20 nmoved:11 900000ms',
+        'reslen:20 nmoved:11 ninserted:100 900000ms',
       '2014-06-02T14:27:48.300-0400 [TTLMonitor] query admin.system.indexes ' +
         'query: { expireAfterSeconds: { $exists: true } } planSummary: EOF ' +
-        'ntoreturn:0 ntoskip:0 nscanned:0 nscannedObjects:0 keyUpdates:9001 ' + 
-        'numYields:0 locks(micros) r:568 nreturned:0 reslen:20 nmoved:11 0ms'
+        'ntoreturn:9 ntoskip:9 nscanned:99 nscannedObjects:0 keyUpdates:9001 ' + 
+        'numYields:9999 locks(micros) w:1111 R:568 nreturned:0 reslen:20 ' + 
+        'nmoved:11 ndeleted:100 nupdated:1000 0ms'
     ],
     expected = [
       {
+        W: 2347,
         collection: 'system',
         database: 'admin',
         duration: 900000,
         keyUpdates: 0,
         namespace: 'admin.system',
+        ninserted: 100,
         nmoved: 11,
         nreturned: 30000,
         nscanned: 0,
@@ -28,24 +31,29 @@ describe('parse', function() {
         ntoskip: 0,
         ntoreturn: 0,
         numYields: 0,
-        operation: 'query',
+        operation: 'command',
+        r: 243,
         reslen: 20
       },
       {
+        R: 568,
         collection: 'system.indexes',
         database: 'admin',
         duration: 0,
         keyUpdates: 9001,
         namespace: 'admin.system.indexes',
+        ndeleted: 100,
         nmoved: 11,
         nreturned: 0,
-        nscanned: 0,
+        nscanned: 99,
         nscannedObjects: 0,
-        ntoskip: 0,
-        ntoreturn: 0,
-        numYields: 0,
+        ntoskip: 9,
+        ntoreturn: 9,
+        nupdated: 1000,
+        numYields: 9999,
         operation: 'query',
-        reslen: 20
+        reslen: 20,
+        w: 1111
       }
     ];
     res = log.parse(lines);


### PR DESCRIPTION
@imlucas 

removed the hardcoded parsing of operation stats
also included lock fields of 'r', 'R', 'w', 'W'
also made the test cases for operations stats more diverse
