### PR TITLE
Parser should ignore lines it can't read

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,10 +28,8 @@ var operationTypes = new Set([
 ]);
 
 function Entry(data, opts){
-  opts = opts || {};
   data = data || {};
-
-  opts.wrap = opts.wrap || 80;
+  opts = opts || {};
 
   // general fields
   parseTimestampFields(this, data.timestamp);
@@ -39,6 +37,7 @@ function Entry(data, opts){
   this.event = getEvent(data.message);
   this.line = data.line;
   this.message = data.message || '';
+
   this.tokens = data.line.split(' ');
   this.thread = data.thread;
 

--- a/patterns.js
+++ b/patterns.js
@@ -32,11 +32,4 @@ regret.add(
   ['line', 'timestamp', 'thread', 'message']
 );
 
-regret.add(
-  'mongodb.logshutdown', 
-  /(\w+)\: (.*)/,
-  'dbexit: really exiting now', 
-  ['name', 'message']
-);
-
 module.exports = regret;

--- a/test/parse.js
+++ b/test/parse.js
@@ -112,6 +112,17 @@ describe('parse', function(){
     }
   });
 
+  it('should parse lines that are not of log format', function() {
+    var lines = [
+      'killcursors: found 0 of 1',
+      'dbexit: really exiting now'
+    ],
+    res = log.parse(lines);
+
+    for (var i = 0; i < lines.length; i++)
+      assert.equal(res[i].line, lines[i]);
+  });
+
   // Wed Jan  1 12:45:05.102 [conn3] build index twitter.tweets  \
   // { lang: 1.0, protected: 1.0 }
   // Wed Jan  1 12:45:05.363 [conn3] build index done.  scanned 51428 total  \


### PR DESCRIPTION
@imlucas 

fixes this issue Thomas raised: https://github.com/imlucas/mongodb-log/issues/24
where the parser would throw an error parsing the line 'killcursors: found 0 of 1'
