### PR TITLE
rewrite object parsing to make it way simpler; also added comment and $q...

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,17 +137,17 @@ function parseQuery(thisObj, currentTokenIndex) {
   var object = JSONL.parse(objectStr);
 
   if (object['$comment'])
-    thisObj.comment = JSONFlatStringify(object['$comment']);
+    thisObj.comment = object['$comment'];
 
   if (object.orderby)
-    thisObj.sortShape = JSONFlatStringify(object.orderby);
+    thisObj.sortShape = object.orderby;
 
   if (object.query)
-    thisObj.query = JSONFlatStringify(object.query)
+    thisObj.query = object.query;
   else if (object['$query'])
-    thisObj.query = JSONFlatStringify(object['$query'])
+    thisObj.query = object['$query'];
   else
-    thisObj.query = objectStr;
+    thisObj.query = object;
 
   parseQueryShape(thisObj);
 
@@ -161,35 +161,25 @@ function JSONFlatStringify(obj) {
   return JSON.stringify(obj, null, ' ').split(/\s+/).join(' ');
 }
 function parseQueryShape(thisObj) {
-  if (thisObj.query === undefined)
-    return;
-  var queryObject;
-  try {
-    queryObject = JSONL.parse(thisObj.query);
-  } catch (e) {
-    debug('Could not parse literal json %s. error: %s', thisObj.query, e);
-    return;
-  }
-  thisObj.queryShape = JSONFlatStringify(
-    parseQueryShapeObject(queryObject)
-  );
-
+  thisObj.queryShape = parseQueryShapeObject(thisObj.query);
   setQueryPattern(thisObj);
 }
 function parseQueryShapeObject(obj) {
+  objCopy = JSON.parse(JSON.stringify(obj));
+
   var value;
-  for (var key in obj) {
-    value = obj[key];
+  for (var key in objCopy) {
+    value = objCopy[key];
     if (QUERY_OPS.indexOf(key) > -1)
       return 1;
     if (Array.isArray(value))
-      obj[key] = parseQueryShapeArray(value);
-    else if (typeof value === 'object' && !(value instanceof RegExp))
-      obj[key] = parseQueryShapeObject(value);
+      objCopy[key] = parseQueryShapeArray(value);
+    else if (typeof value === 'objCopyect' && !(value instanceof RegExp))
+      objCopy[key] = parseQueryShapeObjCopyect(value);
     else
-      obj[key] = 1;
+      objCopy[key] = 1;
   }
-  return obj;
+  return objCopy;
 }
 function parseQueryShapeArray(ary) {
   var ele;
@@ -203,7 +193,8 @@ function parseQueryShapeArray(ary) {
   return ary.sort();
 }
 function setQueryPattern(thisObj) {
-  thisObj.queryPattern = thisObj.namespace + ' ' + thisObj.queryShape;
+  thisObj.queryPattern = thisObj.namespace + ' ' + 
+    JSONFlatStringify(thisObj.queryShape);
 }
 module.exports.parse = function (lines, opts) {
   opts = opts || {};

--- a/test/operation.test.js
+++ b/test/operation.test.js
@@ -12,12 +12,12 @@ describe('Operations', function() {
       'r:93 nreturned:1 reslen:89 0ms'
     ];
     expectedComments = [
-      '{ \"mongoscope_feature\": "get instance collections" }'
+      {"mongoscope_feature":"get instance collections"}
     ];
     res = log.parse(lines);
 
     for (var i = 0; i < lines.length; i++)
-      assert.equal(res[i].comment, expectedComments[i]);
+      assert.deepEqual(res[i].comment, expectedComments[i]);
   }),
 
   // namespace fields
@@ -154,23 +154,23 @@ describe('Operations', function() {
       's" } }'
     ],
     expectedQueries = [
-      '{}',
-      '{ x: 20.0 }',
-      '{ field1: 1 }',
-      '{ field1: [ 1 ] }',
-      '{}',
-      '{ field1: { field2: { field3: \'val3\' }, field4: \'val4\' }, ' +
-      'field5: \'val5\' }',
-      '{ field1: { field2: { query: \'val3\' }, field4: \'val4\' }, ' +
-      'field5: \'val5\' }',
-      '{ \"query\": { \"query\": \"val3\" }, \"field4\": \"val4\" }',
-      '{ field1: /regex/ }',
-      '{ field1: /regex/, field2: { query: /regex/ } }',
-      '{ field: /wefwef " query: acme.*corp/i }',
-      '{ \"query\": \" / val3 / aaa\" }',
-      '{ field1: \'blah \" query: \" query: blah\' }',
-      '{ field1: [ \'a query: a\' ] }',
-      '{}'
+      {},
+      { x: 20.0 },
+      { field1: 1 },
+      { field1: [ 1 ] },
+      {},
+      { field1: { field2: { field3: 'val3' }, field4: 'val4' }, 
+        field5: 'val5' },
+      { field1: { field2: { query: 'val3' }, field4: 'val4' },
+        field5: 'val5' },
+      { "query": { "query": "val3" }, "field4": "val4" },
+      { field1: /regex/ },
+      { field1: /regex/, field2: { query: /regex/ } },
+      { field: /wefwef " query: acme.*corp/i },
+      { "query": " / val3 / aaa" },
+      { field1: 'blah " query: " query: blah' },
+      { field1: [ 'a query: a' ] },
+      {}
     ];
 
     var line, res;
@@ -183,7 +183,7 @@ describe('Operations', function() {
       'nmoved:11 ndeleted:100 nupdated:1000 0ms';
       res = log.parse(line)[0];
 
-      assert.equal(res.query, expectedQueries[i]);
+      assert.deepEqual(res.query, expectedQueries[i]);
     }
   });
 
@@ -213,12 +213,12 @@ describe('Operations', function() {
       '{ expireAfterSeconds: { $exists: 1 } }'
     ],
     expectedQueryShapes = [
-      '{ \"x\": 1 }',
-      '{ \"field\": 1 }',
-      '{ \"f11\": 1, \"f22\": 1, \"f33\": 1, \"$f44\": 1 }',
-      '{ \"f1\": [ 1, 2, 3 ] }',
-      '{ \"query\": 1 }',
-      '{ \"expireAfterSeconds\": 1 }'
+      { "x": 1 },
+      { "field": 1 },
+      { "f11": 1, "f22": 1, "f33": 1, "$f44": 1 },
+      { "f1": [ 1, 2, 3 ] },
+      { "query": 1 },
+      { "expireAfterSeconds": 1 }
     ];
 
     var line, res;
@@ -231,7 +231,7 @@ describe('Operations', function() {
       'nmoved:11 ndeleted:100 nupdated:1000 0ms';
       res = log.parse(line)[0];
 
-      assert.equal(res.queryShape, expectedQueryShapes[i]);
+      assert.deepEqual(res.queryShape, expectedQueryShapes[i]);
     }
   });
 
@@ -246,9 +246,9 @@ describe('Operations', function() {
       'test: \'wee\', orderby: { x123: -1.0 } }'
     ],
     expectedSortShapes = [
-      '{ \"x123\": 1 }',
-      '{ \"x123\": -1 }',
-      '{ \"x123\": -1 }'
+      { "x123": 1 },
+      { "x123": -1 },
+      { "x123": -1 }
     ]
 
     var line, res;
@@ -260,7 +260,7 @@ describe('Operations', function() {
       'nmoved:11 ndeleted:100 nupdated:1000 0ms';
       res = log.parse(line)[0];
 
-      assert.equal(res.sortShape, expectedSortShapes[i]);
+      assert.deepEqual(res.sortShape, expectedSortShapes[i]);
     }
   });
 });


### PR DESCRIPTION
...uery parsing

@imlucas 
1. added parsing of comments
2. added parsing of $query
3. rewrote the parsing of queries, it was way too complex and there was a lot simpler solution by using JSONL
4. changed objects strings to actual objects e.g.
"{ attr: 1 }" is now { attr: 1 }, so the MessagesView can actually filter on attributes of those actual objects whereas we couldn't do that if they were strings
